### PR TITLE
Ensure that changes to input .proto files are watched

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -3,6 +3,6 @@ builders:
     import: "package:protoc_builder/protoc_builder.dart"
     builder_factories: ["getBuilder"]
     build_extensions: {
-      ".proto": [".dart"]
+      ".proto": [".dart", ".pb"]
     }
     auto_apply: dependents

--- a/example/build.yaml
+++ b/example/build.yaml
@@ -12,3 +12,4 @@ targets:
           proto_paths:
             - "proto/"
           out_dir: "lib/src/generated"
+          build_descriptor: true

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -62,6 +62,16 @@ class ProtocBuilder implements Builder {
         path.join('.', inputPath),
       ],
     );
+
+    // Just as with the read, the build runner spies on what we write, so we
+    // need to write each output file explicitly, even though they've already
+    // been written by protoc. This will ensure that if an output file is
+    // deleted, a future build will recreate it. This also checks that the files
+    // we were expected to write were actually written, since this will fail if
+    // an output file wasn't created by protoc.
+    await Future.wait(buildStep.allowedOutputs.map((AssetId out) async {
+      await buildStep.writeAsBytes(out, File(out.path).readAsBytes());
+    }));
   }
 
   @override

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -47,6 +47,10 @@ class ProtocBuilder implements Builder {
 
     final inputPath = path.normalize(buildStep.inputId.path);
 
+    // Read the input path to signal to the build graph that if the file changes
+    // than it should be rebuilt.
+    await buildStep.readAsString(buildStep.inputId);
+
     await Directory(outputDirectory).create(recursive: true);
     await ProcessExtensions.runSafely(
       protoc.path,


### PR DESCRIPTION
Without this, the build system won't notice that a .proto file has been
changed and will not invoke the builder again.

Tested this in the example/ directory with `dart run build_runner watch`
and making changes to the `proto/my_proto.proto` file and watching the
resulting `.dart` files be regenerated.

Fixes #1 