### PR TITLE
Ensure that changes to input .proto files are watched

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -62,6 +62,16 @@ class ProtocBuilder implements Builder {
         path.join('.', inputPath),
       ],
     );
+
+    // Just as with the read, the build runner spies on what we write, so we
+    // need to write each output file explicitly, even though they've already
+    // been written by protoc. This will ensure that if an output file is
+    // deleted, a future build will recreate it. This also checks that the files
+    // we were expected to write were actually written, since this will fail if
+    // an output file wasn't created by protoc.
+    await Future.wait(buildStep.allowedOutputs.map((AssetId out) async {
+      await buildStep.writeAsBytes(out, File(out.path).readAsBytes());
+    }));
   }
 
   @override

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -47,6 +47,10 @@ class ProtocBuilder implements Builder {
 
     final inputPath = path.normalize(buildStep.inputId.path);
 
+    // Read the input path to signal to the build graph that if the file changes
+    // than it should be rebuilt.
+    await buildStep.readAsString(buildStep.inputId);
+
     await Directory(outputDirectory).create(recursive: true);
     await ProcessExtensions.runSafely(
       protoc.path,


### PR DESCRIPTION
Without this, the build system won't notice that a .proto file has been
changed and will not invoke the builder again.

I updated this with another commit that ensures that output files will be recreated if they are deleted. However, due to a minor bug, it seems that it only watches the first output file in the list of buildExtensions, so if one removes the '{{}}.pb.dart' file, it will trigger a regenerate, but removing the other files won't.

Tested this in the example/ directory with dart run build_runner watch
and making changes to the proto/my_proto.proto file and watching the
resulting .dart files be regenerated.

Fixes #1