### PR TITLE
Support protoc_plugin v20.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ targets:
           # (Default: "3.19.1", make sure to use quotation marks)
           protobuf_version: "3.19.1"
           # The version of the Dart protoc_plugin package to use.
-          # (Default: "20.0.0", make sure to use quotation marks)
-          protoc_plugin_version: "20.0.0"
+          # (Default: "20.0.1", make sure to use quotation marks)
+          protoc_plugin_version: "20.0.1"
           # Directory which is treated as the root of all Protobuf files.
           # (Default: "proto/")
           root_dir: "proto/"

--- a/example/build.yaml
+++ b/example/build.yaml
@@ -11,8 +11,8 @@ targets:
           # (Default: "3.19.1", make sure to use quotation marks)
           protobuf_version: "3.19.1"
           # The version of the Dart protoc_plugin package to use.
-          # (Default: "20.0.0", make sure to use quotation marks)
-          protoc_plugin_version: "20.0.0"
+          # (Default: "20.0.1", make sure to use quotation marks)
+          protoc_plugin_version: "20.0.1"
           # Directory which is treated as the root of all Protobuf files.
           # (Default: "proto/")
           root_dir: "proto/"

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -11,7 +11,7 @@ import 'protoc_download.dart';
 
 class ProtocBuilder implements Builder {
   static const defaultProtocVersion = '3.19.1';
-  static const defaultProtocPluginVersion = '20.0.0';
+  static const defaultProtocPluginVersion = '20.0.1';
   static const defaultRootDirectory = 'proto/';
   static const defaultProtoPaths = ['proto/'];
   static const defaultOutputDirectory = 'lib/src/proto/';


### PR DESCRIPTION
### Summary
Bumped the default protoc_plugin version to the latest v20.0.1 (which fixes mono_repo configuration after a breaking change)

#### Notes
protoc_plugin v20.0.1 adds a [local relative dependency override](https://github.com/google/protobuf.dart/blob/master/protoc_plugin/pubspec.yaml#L25) to the protobuf package so I needed to also unpack and `pub get` it