### PR TITLE
Added option to use local `protoc` instead of downloading one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+* Added option to use local `protoc` instead of downloading one (saves about 10 seconds per build)
+
 ## 0.3.0
 
 * Support plugin version 20.0.1 (thank you to [stasgora](https://github.com/stasgora)!)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ targets:
           # Enable the gRPC flag for the Dart protoc plugin to generate `.pbgrpc.dart` files.
           # (Default: false)
           grpc: true
+          # Use the "protoc" command that's available on the PATH instead of downloading one
+          # (Default: false)
+          use_installed_protoc: false
 ```
 
 ## Running


### PR DESCRIPTION
I was looking to implement my own "protoc builder" when I stumbled upon this one. It works perfectly for me, the only issue I have is that I already got `protoc` and `protoc_plugin` installed on my machine. So a logical addition, at least to me, was to add an option to use the `protoc` command from the path, instead of downloading one every time. This shaves off about 10 seconds on each build.