### PR TITLE
Extracted methods and expose `ProtocBuilder` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.2
+
+* Extracted options that might be useful when overriding the ProtocBuilder class.
+* Export the `builder.dart` file so the ProtocBuilder class can actually be found.
+
 ## 0.3.1
 
 * Added option to use local `protoc` instead of downloading one (saves about 10 seconds per build)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+* Added option to use local `protoc` instead of downloading one (saves about 10 seconds per build)
+
 ## 0.3.0
 
 * Support plugin version 20.0.1 (thank you to [stasgora](https://github.com/stasgora)!)

--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ targets:
           # Enable the gRPC flag for the Dart protoc plugin to generate `.pbgrpc.dart` files.
           # (Default: false)
           grpc: true
+          # Use the "protoc" command that's available on the PATH instead of downloading one
+          # (Default: false)
+          use_installed_protoc: false
 ```
 
 ## Running

--- a/lib/protoc_builder.dart
+++ b/lib/protoc_builder.dart
@@ -4,4 +4,6 @@ import 'package:build/build.dart';
 
 import 'src/builder.dart';
 
+export 'src/builder.dart';
+
 Builder getBuilder(BuilderOptions options) => ProtocBuilder(options);


### PR DESCRIPTION
For use in my unit tests, I need to do some replacements on the AssetId paths. In order to do so, I've extracted 2 methods that can be overridden in a subclass of the original `ProtocBuilder` class.

For reference, our test method:
```dart
test('Run protoc builder', () async {
  final sourceAssets = await loadProtoFileInputAssets(protoFiles);
  final outputAssets = await loadProtocolBufferOutputAssets(dartFiles);

  ProtocBuilder builder = TestAssetProtocBuilder(BuilderOptions({
    'use_installed_protoc': true,
    'root_dir': 'lib/proto',
    'proto_paths': YamlList.wrap(['lib/proto']),
    'out_dir': 'lib/protobuf',
  }));
  await testBuilder(
    builder,
    sourceAssets,
    outputs: outputAssets,
    reader: TestAssetReader,
  );
});
```
And our custom ProtocBuilder implementation:
```dart
class TestAssetProtocBuilder extends ProtocBuilder {

  TestAssetProtocBuilder(super.options);

  @override
  List<String> collectProtocArguments(File protocPlugin, String pluginParameters, String inputPath) {
    return super
        .collectProtocArguments(protocPlugin, pluginParameters, inputPath)
        .map((p) => p.replaceFirst('lib', 'test/assets'))
        .toList();
  }

  @override
  File loadOutputFile(AssetId out) {
    return File(out.path.replaceFirst('lib', 'test/assets'));
  }
}
```
