### PR TITLE
Fixes Issue #15: race conditions fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 # Conventional directory for build outputs.
 build/
 
+.idea/
+
 # Omit committing pubspec.lock for library packages; see
 # https://dart.dev/guides/libraries/private-files#pubspeclock.
 pubspec.lock

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -61,7 +61,6 @@ class ProtocBuilder implements Builder {
   @override
   Future<void> build(BuildStep buildStep) async {
     // When "useInstalledProtoc", we will not fetch any external resources
-    print("Executing buildStep $buildStep");
     final protoc = useInstalledProtoc
         ? File('protoc')
         : await fetchProtoc(protobufVersion);

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -61,6 +61,7 @@ class ProtocBuilder implements Builder {
   @override
   Future<void> build(BuildStep buildStep) async {
     // When "useInstalledProtoc", we will not fetch any external resources
+    print("Executing buildStep $buildStep");
     final protoc = useInstalledProtoc
         ? File('protoc')
         : await fetchProtoc(protobufVersion);

--- a/lib/src/protoc_download.dart
+++ b/lib/src/protoc_download.dart
@@ -31,6 +31,9 @@ String _protocExecutableName() {
   return Platform.isWindows ? 'protoc.exe' : 'protoc';
 }
 
+/// Guard to avoid multiple download of protoc compiler.
+bool protocFetched = false;
+
 /// Downloads the Protobuf compiler from the GitHub Releases page and extracts
 /// it to a temporary working directory.
 /// Returns the path to the protoc executable that can be used by a [Process].
@@ -43,10 +46,11 @@ Future<File> fetchProtoc(String version) async {
   final protoc = File(
     path.join(versionDirectory.path, 'bin', _protocExecutableName()),
   );
+  if (protocFetched) return protoc;
+  protocFetched = true;
 
   // If the compiler version has already been downloaded, the function is done.
   if (await versionDirectory.exists()) return protoc;
-
   // Download and unzip the .zip file containing protoc and Google .proto files.
   await unzipUri(_protocUriFromVersion(version), versionDirectory);
 

--- a/lib/src/protoc_download.dart
+++ b/lib/src/protoc_download.dart
@@ -46,11 +46,17 @@ Future<File> fetchProtoc(String version) async {
   final protoc = File(
     path.join(versionDirectory.path, 'bin', _protocExecutableName()),
   );
-  if (protocFetched) return protoc;
+  if (protocFetched) {
+    int retries = 0;
+    // If the compiler version has already been downloaded, the function is done.
+    while (!await protoc.exists() && retries < 10) {
+      await Future.delayed(Duration(milliseconds: 100));
+      retries++;
+    }
+    return protoc;
+  }
   protocFetched = true;
 
-  // If the compiler version has already been downloaded, the function is done.
-  if (await versionDirectory.exists()) return protoc;
   // Download and unzip the .zip file containing protoc and Google .proto files.
   await unzipUri(_protocUriFromVersion(version), versionDirectory);
 

--- a/lib/src/protoc_download.dart
+++ b/lib/src/protoc_download.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ffi';
 import 'dart:io';
 
 import 'package:path/path.dart' as path;
@@ -11,18 +12,16 @@ final Directory _compilerDirectory =
 
 Uri _protocUriFromVersion(String version) {
   String platformString;
-  switch (Platform.operatingSystem) {
-    case 'windows':
-      platformString = 'win64';
-      break;
-    case 'macos':
-      platformString = 'osx-x86_64';
-      break;
-    case 'linux':
-      platformString = 'linux-x86_64';
-      break;
-    default:
-      throw UnsupportedError('Build platform not supported.');
+  if (Platform.isWindows) {
+    platformString = Abi.current() == Abi.windowsIA32 ? 'win32' : 'win64';
+  } else if (Platform.isMacOS) {
+    platformString =
+      Abi.current() == Abi.macosArm64 ? 'osx-aarch_64' : 'osx-x86_64';
+  } else if (Platform.isLinux) {
+    platformString =
+      Abi.current() == Abi.linuxArm64 ? 'linux-aarch_64' : 'linux-x86_64';
+  } else {
+    throw UnsupportedError('Build platform not supported.');
   }
   return Uri.parse(
       'https://github.com/protocolbuffers/protobuf/releases/download/v$version/protoc-$version-$platformString.zip');

--- a/lib/src/protoc_plugin_download.dart
+++ b/lib/src/protoc_plugin_download.dart
@@ -17,6 +17,37 @@ String _protoPluginName() {
   return Platform.isWindows ? 'protoc-gen-dart.bat' : 'protoc-gen-dart';
 }
 
+class RunOnceProcess {
+  bool onTheRun = false;
+  bool done = false;
+}
+
+RunOnceProcess _unpack = RunOnceProcess();
+RunOnceProcess _precompile = RunOnceProcess();
+
+///
+/// Wrap the process of unpacking the protoc plugin into
+Future<void> _executeOnce(RunOnceProcess processState, Future<bool> Function() unpack) async {
+  if (processState.done) {
+    // print("Protoc compiler had been unpacked already.");
+    return;
+  }
+  while (processState.onTheRun) {
+    // print("waiting for other process unpacking protoc compiler");
+    await Future.delayed(const Duration(seconds: 1));
+  }
+  if (!processState.done) {
+    //print("Need to unpack the protoc compiler");
+    processState.onTheRun = true;
+    try {
+      processState.done = await unpack();
+      //print("Protoc compiler was unpacked with success=$_unpacked");
+    } finally {
+      processState.onTheRun = false;
+    }
+  }
+}
+
 /// Downloads the Dart plugin for the Protobuf compiler from the GitHub Releases
 /// page and extracts it to a temporary working directory.
 /// Returns the path to the binaries directory that should be added to the PATH
@@ -47,26 +78,36 @@ Future<File> fetchProtocPlugin(
     ),
   );
 
-  // If the plugin has not been downloaded yet, download it.
-  if (!await versionDirectory.exists()) {
-    // Download and unzip the .zip file containing protoc and Google .proto files.
-    await unzipUri(
-      _protocPluginUriFromVersion(version),
-      versionDirectory,
-      // Only extract the protoc_plugin from the Protobuf Git repository.
-      (file) => packages.contains(path.split(file.name)[1]),
-    );
+  await _executeOnce(_unpack, () async {
+    try {
+      // If the plugin has not been downloaded yet, download it.
+      if (!await versionDirectory.exists()) {
+        // Download and unzip the .zip file containing protoc and Google .proto files.
+        await unzipUri(
+          _protocPluginUriFromVersion(version),
+          versionDirectory,
+          // Only extract the protoc_plugin from the Protobuf Git repository.
+              (file) => packages.contains(path.split(file.name)[1]),
+        );
 
-    // Fetch protoc_plugin package dependencies.
-    await Future.wait(packages.map((pkg) => ProcessExtensions.runSafely(
-          'dart',
-          ['pub', 'get'],
-          workingDirectory: path.join(protocPluginPackageDirectory.path, pkg),
-        )));
+        // Fetch protoc_plugin package dependencies.
+        await Future.wait(packages.map((pkg) =>
+            ProcessExtensions.runSafely(
+              'dart',
+              ['pub', 'get'],
+              workingDirectory: path.join(
+                  protocPluginPackageDirectory.path, pkg),
+            )));
 
-    // Make plugin executable on non-Windows platforms.
-    await addRunnableFlag(protocPlugin);
-  }
+        // Make plugin executable on non-Windows platforms.
+        await addRunnableFlag(protocPlugin);
+      }
+      return true;
+    } catch(ex) {
+      print("Failed to unpack protoc plugin with $ex.");
+      return false;
+    }
+  });
 
   if (precompileProtocPlugin) {
     final precompiledName = "precompiled.exe";
@@ -76,23 +117,25 @@ Future<File> fetchProtocPlugin(
         precompiledName,
       ),
     );
-    if (!await precompiledProtocPlugin.exists()) {
-      // Compile the entry point file.
-      await ProcessExtensions.runSafely(
-        'dart',
-        [
-          'compile',
-          'exe',
-          'bin/protoc_plugin.dart',
-          '-o',
-          precompiledName,
-        ],
-        workingDirectory: protocPluginDirectory.path,
-      );
-
-      // Make sure the executable is runnable on non-Windows platforms.
-      await addRunnableFlag(precompiledProtocPlugin);
-    }
+    await _executeOnce(_precompile, () async {
+      if (!await precompiledProtocPlugin.exists()) {
+        // Compile the entry point file.
+        await ProcessExtensions.runSafely(
+          'dart',
+          [
+            'compile',
+            'exe',
+            'bin/protoc_plugin.dart',
+            '-o',
+            precompiledName,
+          ],
+          workingDirectory: protocPluginDirectory.path,
+        );
+        // Make sure the executable is runnable on non-Windows platforms.
+        await addRunnableFlag(precompiledProtocPlugin);
+      }
+      return true;
+    });
     return precompiledProtocPlugin;
   } else {
     return protocPlugin;

--- a/lib/src/utility.dart
+++ b/lib/src/utility.dart
@@ -17,6 +17,7 @@ final Directory temporaryDirectory =
 /// limit the amount of files extracted from the archive.
 Future<void> unzipUri(Uri uri, Directory target,
     [bool Function(ArchiveFile file)? test]) async {
+
   final archive = ZipDecoder().decodeBytes(await http.readBytes(uri));
   for (final file in archive) {
     final filename = file.name;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.4.0
 repository: https://github.com/pikaju/dart-protoc-builder
 
 environment:
-  sdk: ">=2.14.4 <4.0.0"
+  sdk: ">=2.16.0 <4.0.0"
 
 dependencies:
   archive: ^3.1.6


### PR DESCRIPTION
When compiling many protobuf files at once, the protoc_builder plugin showed several race conditions copying and pre-compiling files as multiple builders are started concurrently executing code to download files, create directories and (optionally) pre-compiling the protoc plugin. This fix ensures, that each of the corresponding operations is performed once ensuring other builders to wait until the corresponding action had been performed.
