### PR TITLE
feat: Add use_protoc_plugin_from_pubspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ targets:
           # The version of the Dart protoc_plugin package to use.
           # (Default: "20.0.1", make sure to use quotation marks)
           protoc_plugin_version: "20.0.1"
+          # Prefer the protoc_plugin defined by a dev_dependency.
+          # (Default: true)
+          # Takes priority over protoc_plugin_version and use_installed_protoc.
+          use_protoc_plugin_from_pubspec: true
           # Directory which is treated as the root of all Protobuf files.
           # (Default: "proto/")
           root_dir: "proto/"

--- a/lib/src/protoc_plugin_download.dart
+++ b/lib/src/protoc_plugin_download.dart
@@ -115,9 +115,6 @@ Future<File> fetchProtocPlugin(
       if (!await versionDirectory.exists()) {
         await fetcher.fetchInto(versionDirectory);
 
-        print(
-            'workDir: ${path.join(protocPluginPackageDirectory.path, 'protoc_plugin')}');
-
         // Fetch protoc_plugin package dependencies.
         await Future.wait(packages.map((pkg) => ProcessExtensions.runSafely(
               'dart',

--- a/lib/src/protoc_plugin_pubspec.dart
+++ b/lib/src/protoc_plugin_pubspec.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+
+import 'package:package_config/package_config.dart';
+import 'package:path/path.dart' as path;
+import 'package:protoc_builder/src/utility.dart';
+
+import 'protoc_plugin_download.dart';
+
+class ProtocFromPubspec extends ProtocFetcher {
+  final Package pluginPackage;
+  final Package protobufPackage;
+
+  ProtocFromPubspec({
+    required this.pluginPackage,
+    required this.protobufPackage,
+  });
+
+  @override
+  Future<void> fetchInto(Directory target) async {
+    await Future.wait([
+      copyDirectory(
+          Directory.fromUri(pluginPackage.root),
+          Directory(path.join(
+              target.path, 'protobuf.dart-protoc_plugin', 'protoc_plugin'))),
+      copyDirectory(
+          Directory.fromUri(protobufPackage.root),
+          Directory(path.join(
+              target.path, 'protobuf.dart-protoc_plugin', 'protobuf'))),
+    ]);
+  }
+
+  @override
+  Directory versionDirectory() {
+    var root = path.split(Directory.fromUri(pluginPackage.root).path);
+    var last = root.removeLast();
+
+    return Directory(path.join(
+      pluginDirectory.path,
+      root.last,
+      last,
+    ));
+  }
+}
+
+Future<File?> protocPluginPubspecCommand(bool precompileProtocPlugin) async {
+  var packageConfig = await findPackageConfig(Directory.current);
+  if (packageConfig != null) {
+    Package? pluginPackage;
+    Package? protobufPackage;
+
+    for (var package in packageConfig.packages) {
+      if (package.name == 'protoc_plugin') {
+        pluginPackage = package;
+      } else if (package.name == 'protobuf') {
+        protobufPackage = package;
+      }
+      if (pluginPackage != null && protobufPackage != null) {
+        return await fetchProtocPlugin(
+          ProtocFromPubspec(
+            pluginPackage: pluginPackage,
+            protobufPackage: protobufPackage,
+          ),
+          precompileProtocPlugin,
+        );
+      }
+    }
+    return null;
+  } else {
+    return null;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   http: ">=0.13.4 <2.0.0"
   path: ^1.8.0
   yaml: ^3.1.0
+  package_config: ^2.1.0
 
 dev_dependencies:
   lints: ">=1.0.0 <3.0.0"


### PR DESCRIPTION
This change allows the user to set the `protoc_plugin` as a `dev_dependency`.

By default, the builder checks if `protoc_plugin` is a dependency (part of `package_config.json`) and uses it if it is availible. If it's no dependency, the old behavior applies.

This feature can be disabled by setting `use_protoc_plugin_from_pubspec` to false.

*Some more testing is probably adequate, since I've just used this version with a `protoc_plugin` in a custom git branch.*

Close #20 