### PR TITLE
Added well known types support

### DIFF
--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -24,6 +24,7 @@ class ProtocBuilder implements Builder {
   static const defaultGrpcEnabled = false;
   static const defaultUseInstalledProtoc = false;
   static const defaultPrecompileProtocPlugin = true;
+  static const defaultWellKnownTypesEnabled = false;
 
   ProtocBuilder(this.options)
       : protobufVersion = options.config['protobuf_version'] as String? ??
@@ -45,7 +46,10 @@ class ProtocBuilder implements Builder {
             defaultUseInstalledProtoc,
         precompileProtocPlugin =
             options.config['precompile_protoc_plugin'] as bool? ??
-                defaultPrecompileProtocPlugin;
+                defaultPrecompileProtocPlugin,
+        wellKnownTypesEnabled =
+            options.config['wellKnownTypesEnabled'] as bool? ??
+                defaultWellKnownTypesEnabled;
 
   final BuilderOptions options;
 
@@ -57,6 +61,23 @@ class ProtocBuilder implements Builder {
   final bool grpcEnabled;
   final bool useInstalledProtoc;
   final bool precompileProtocPlugin;
+  final bool wellKnownTypesEnabled;
+
+  late final List<String> wellKnownTypes = wellKnownTypesEnabled
+      ? [
+          'google/protobuf/any.proto',
+          'google/protobuf/api.proto',
+          'google/protobuf/descriptor.proto',
+          'google/protobuf/duration.proto',
+          'google/protobuf/empty.proto',
+          'google/protobuf/field_mask.proto',
+          'google/protobuf/source_context.proto',
+          'google/protobuf/struct.proto',
+          'google/protobuf/timestamp.proto',
+          'google/protobuf/type.proto',
+          'google/protobuf/wrappers.proto'
+        ]
+      : [];
 
   @override
   Future<void> build(BuildStep buildStep) async {
@@ -117,6 +138,7 @@ class ProtocBuilder implements Builder {
       ...protoPaths
           .map((protoPath) => '--proto_path=${path.join('.', protoPath)}'),
       path.join('.', inputPath),
+      ...wellKnownTypes
     ];
   }
 

--- a/lib/src/builder.dart
+++ b/lib/src/builder.dart
@@ -26,6 +26,20 @@ class ProtocBuilder implements Builder {
   static const defaultPrecompileProtocPlugin = true;
   static const defaultWellKnownTypesEnabled = false;
 
+  static const List<String> wellKnownTypes = [
+    'google/protobuf/any.proto',
+    'google/protobuf/api.proto',
+    'google/protobuf/descriptor.proto',
+    'google/protobuf/duration.proto',
+    'google/protobuf/empty.proto',
+    'google/protobuf/field_mask.proto',
+    'google/protobuf/source_context.proto',
+    'google/protobuf/struct.proto',
+    'google/protobuf/timestamp.proto',
+    'google/protobuf/type.proto',
+    'google/protobuf/wrappers.proto'
+  ];
+
   ProtocBuilder(this.options)
       : protobufVersion = options.config['protobuf_version'] as String? ??
             defaultProtocVersion,
@@ -62,22 +76,6 @@ class ProtocBuilder implements Builder {
   final bool useInstalledProtoc;
   final bool precompileProtocPlugin;
   final bool wellKnownTypesEnabled;
-
-  late final List<String> wellKnownTypes = wellKnownTypesEnabled
-      ? [
-          'google/protobuf/any.proto',
-          'google/protobuf/api.proto',
-          'google/protobuf/descriptor.proto',
-          'google/protobuf/duration.proto',
-          'google/protobuf/empty.proto',
-          'google/protobuf/field_mask.proto',
-          'google/protobuf/source_context.proto',
-          'google/protobuf/struct.proto',
-          'google/protobuf/timestamp.proto',
-          'google/protobuf/type.proto',
-          'google/protobuf/wrappers.proto'
-        ]
-      : [];
 
   @override
   Future<void> build(BuildStep buildStep) async {
@@ -138,7 +136,7 @@ class ProtocBuilder implements Builder {
       ...protoPaths
           .map((protoPath) => '--proto_path=${path.join('.', protoPath)}'),
       path.join('.', inputPath),
-      ...wellKnownTypes
+      if (wellKnownTypesEnabled) ...wellKnownTypes
     ];
   }
 


### PR DESCRIPTION
Add an option to generate the following well-known types for #4:

- google/protobuf/any.proto
- google/protobuf/api.proto
- google/protobuf/descriptor.proto
- google/protobuf/duration.proto
- google/protobuf/empty.proto
- google/protobuf/field_mask.proto
- google/protobuf/source_context.proto
- google/protobuf/struct.proto
- google/protobuf/timestamp.proto
- google/protobuf/type.proto
- google/protobuf/wrappers.proto