### PR TITLE
Updated Dependencies to accept build v4, archive v4

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,12 +7,12 @@ environment:
   sdk: ">=2.16.0 <4.0.0"
 
 dependencies:
-  archive: ^3.1.6
-  build: ^2.1.1
+  archive: ">=3.1.6 <5.0.0"
+  build: ">=2.1.1 <5.0.0"
   http: ">=0.13.4 <2.0.0"
   path: ^1.8.0
   yaml: ^3.1.0
 
 dev_dependencies:
-  lints: ">=1.0.0 <3.0.0"
-  test: ^1.16.0
+  lints: ">=1.0.0 <7.0.0"
+  test: ^1.27.0


### PR DESCRIPTION
Before these changes, one needs to use dependency_overrides to use the latest stable build and archive packages as this package (protoc_builder) is stuck with older versions. The package works just fine with the latest versions of build and archive. And while its technically possible to use dependency_overrides, forcing a developer to do so is a really bad idea as this will also overrides the dependencies of any other package and especially with the build package, this might lead to issues quickly.