### PR TITLE
Added support for protoc_plugin >= 23.0.0 with workspace pubspec.yaml

### DIFF
--- a/lib/src/protoc_plugin_download.dart
+++ b/lib/src/protoc_plugin_download.dart
@@ -1,6 +1,9 @@
 import 'dart:io';
 
+import 'package:build/build.dart';
 import 'package:path/path.dart' as path;
+import 'package:pub_semver/pub_semver.dart';
+import 'package:yaml/yaml.dart';
 
 import 'utility.dart';
 
@@ -92,15 +95,9 @@ Future<File> fetchProtocPlugin(
           // Only extract the protoc_plugin from the Protobuf Git repository.
               (file) => packages.contains(path.split(file.name)[1]),
         );
-
-        // Fetch protoc_plugin package dependencies.
-        await Future.wait(packages.map((pkg) =>
-            ProcessExtensions.runSafely(
-              'dart',
-              ['pub', 'get'],
-              workingDirectory: path.join(
-                  protocPluginPackageDirectory.path, pkg),
-            )));
+        
+        // Fetch dependencies for the downloaded protoc plugin packages.
+        await _fetchDependencies(protocPluginPackageDirectory.path, packages);
 
         // Make plugin executable on non-Windows platforms.
         await addRunnableFlag(protocPlugin);
@@ -142,5 +139,93 @@ Future<File> fetchProtocPlugin(
     return precompiledProtocPlugin;
   } else {
     return protocPlugin;
+  }
+}
+
+/// Fetches dependencies for the downloaded protoc plugin packages.
+///
+/// This function iterates through all packages, separating them into standalone
+/// and workspace-based packages. It runs `pub get` for standalone packages
+/// individually. For workspace packages, it determines the most compatible SDK
+/// constraint, generates a workspace `pubspec.yaml`, and runs `pub get` once.
+Future<void> _fetchDependencies(
+  String protocPluginPackageDirectory,
+  List<String> packages,
+) async {
+  final standalonePackages = <String>[];
+  final workspacePackages = <String>[];
+
+  // For workspace packages, we'll try to find the sdk constrain
+  VersionConstraint? workspaceSdkConstraint;
+  String workspaceSdkVersionStr = '">=3.5.0"';
+
+  for (final package in packages) {
+    final pubspecFile = File(path.join(
+      protocPluginPackageDirectory,
+      package,
+      'pubspec.yaml',
+    ));
+
+    if (!await pubspecFile.exists()) continue;
+
+    final pubspecContent = await pubspecFile.readAsString();
+    final pubspecYaml = loadYaml(pubspecContent) as YamlMap;
+
+    if (pubspecYaml['resolution'] != 'workspace') {
+      standalonePackages.add(package);
+    } else {
+      workspacePackages.add(package);
+      final sdkConstraintStr = pubspecYaml['environment']?['sdk'] as String?;
+      if (sdkConstraintStr != null) {
+        final sdkConstraint = VersionConstraint.parse(sdkConstraintStr);
+        if (workspaceSdkConstraint == null) {
+          workspaceSdkConstraint = sdkConstraint;
+        } else {
+          final mergedConstraints = workspaceSdkConstraint.union(sdkConstraint);
+          if (mergedConstraints.isEmpty) {
+            log.warning(
+                "Failed to merge SDK constraints for workspace packages, ignoring $sdkConstraintStr as it did not merge with $workspaceSdkVersionStr.");
+          } else {
+            workspaceSdkConstraint = mergedConstraints;
+          }
+        }
+
+        workspaceSdkVersionStr = workspaceSdkConstraint.toString();
+      }
+    }
+  }
+
+  // Fetch dependencies for standalone packages individually.
+  if (standalonePackages.isNotEmpty) {
+    await Future.wait(
+        standalonePackages.map((pkg) => ProcessExtensions.runSafely(
+              'dart',
+              ['pub', 'get'],
+              workingDirectory: path.join(protocPluginPackageDirectory, pkg),
+            )));
+  }
+
+  // If there are workspace packages, handle them together.
+  if (workspacePackages.isNotEmpty) {
+    // Create a temporary pubspec.yaml to define the workspace.
+    final workspacePubspec = File(
+      path.join(protocPluginPackageDirectory, 'pubspec.yaml'),
+    );
+    await workspacePubspec.writeAsString('''
+name: _protoc_builder_workspace
+publish_to: none
+environment:
+  sdk: '$workspaceSdkVersionStr'
+
+workspace:
+${workspacePackages.map((p) => '  - $p').join('\n')}
+''');
+
+    // Fetch dependencies for all packages in the workspace.
+    await ProcessExtensions.runSafely(
+      'dart',
+      ['pub', 'get'],
+      workingDirectory: protocPluginPackageDirectory,
+    );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   http: ">=0.13.4 <2.0.0"
   path: ^1.8.0
   yaml: ^3.1.0
+  pub_semver: ">=2.0.0 <3.0.0"
 
 dev_dependencies:
   lints: ">=1.0.0 <3.0.0"


### PR DESCRIPTION
protoc_plugin changed it's packages to use the workspace pattern for it's pubspec files as described here https://dart.dev/tools/pub/workspaces

version 23.0.0 and beyond of the `protoc_plugin` fail on the `pub get` call on the inividual packages.

this PR adds a stage to inspect the packages, then does the regular `pub get` on any package not using the workspace pattern yet and creates a temporary `pubspec.yaml` acting as the workspace for all plugins using the workspace mechanism.

So after this PR, `pub get` works all scenarios.